### PR TITLE
Convert de_DE to UTF-8

### DIFF
--- a/massiveAdmin/lang/de_DE.php
+++ b/massiveAdmin/lang/de_DE.php
@@ -5,13 +5,13 @@ $i18n = [
 	'MAINTENANCE_ON' 				=> 'Wartungsmodus Ein?',
 	'CONTENT_MAINTENANCE_MODE' 		=> 'Inhalt des Wartungsmodus:',
 	'TURNONBOOTSTRAPGRID' 			=> 'Bootstrap-Grid 4.0 einschalten?',
-	'TURNONBOOTSTRAPGRIDONTHEME' 	=> 'Bootstrap-Grid-CSS zum Frontend-Theme hinzufügen?',
+	'TURNONBOOTSTRAPGRIDONTHEME' 	=> 'Bootstrap-Grid-CSS zum Frontend-Theme hinzufÃ¼gen?',
 	'YES' 							=> 'Ja',
 	'NO' 							=> 'Nein',
-	'SAVEOPTION' 					=> 'Änderungen speichern',
-	'SUPPORT' 						=> 'Wenn Sie meine Arbeit über PayPal unterstützen möchten :) Danke! ',
+	'SAVEOPTION' 					=> 'Ã„nderungen speichern',
+	'SUPPORT' 						=> 'Wenn Sie meine Arbeit Ã¼ber PayPal unterstÃ¼tzen mÃ¶chten :) Danke! ',
 	'UPLOADFILE' 					=> 'Datei hochladen',
-	'ANOTHERPAGE' 					=> '<strong>Änderungen gespeichert!</strong> Gehe zu einer anderen Seite:)',
+	'ANOTHERPAGE' 					=> '<strong>Ã„nderungen gespeichert!</strong> Gehe zu einer anderen Seite:)',
 	'EDITCOMPONENTS' 				=> 'Komponenten bearbeiten',
 	'MASSIVEADMINSETTINGSTITLE' 	=> 'MassiveAdmin-Einstellungen',
 	'DROPFILES' 					=> 'Dateien hier zum Hochladen ablegen',
@@ -19,7 +19,7 @@ $i18n = [
 
 	//options on file edit
 	'COPYFILE' 						=> 'Datei kopieren',
-	'RENAMEFILE' 					=> 'Verzeichnis umbenennen / ändern',
+	'RENAMEFILE' 					=> 'Verzeichnis umbenennen / Ã¤ndern',
 	'DOWNLOADFILE' 					=> 'Herunterladen',
 	'INFOCOPY' 						=> 'Ihre kopierte Datei befindet sich in ',
 	'INFOERROR' 					=> 'Eine Datei mit diesem Namen existiert bereits in diesem Verzeichnis ',
@@ -36,16 +36,16 @@ $i18n = [
 	'HIDEMENUTITLE' 				=> 'Benutzermanager & Abschnitte',
 	'SHOW' 							=> 'Zeigen',
 	'HIDE' 							=> 'Verstecken',
-	'HIDSECTIONTITLE' 				=> 'Welche Abschnitte möchten Sie ausblenden?',
-	'HIDEPAGES' 					=> 'Abschnitt „<strong>Seiten</strong>“ ausblenden?',
-	'HIDEFILES' 					=> 'Abschnitt „<strong>Dateien</strong>“ ausblenden?',
-	'HIDETHEMES' 					=> 'Abschnitt „<strong>Themen</strong>“ ausblenden?',
-	'HIDEBACKUP' 					=> 'Abschnitt „<strong>Backup</strong>“ ausblenden?',
-	'HIDEPLUGIN' 					=> 'Abschnitt „<strong>Plugin</strong>“ ausblenden?',
-	'HIDESUPPORT' 					=> 'Abschnitt „<strong>Support</strong>“ ausblenden?',
-	'HIDESETTINGS' 					=> 'Abschnitt „<strong>MassiveAdmin-Einstellungen</strong>“ ausblenden?',
-	'HIDEI18NGALLERY' 				=> 'Abschnitt „<strong>i18n-Galerie</strong>“ ausblenden? (falls vorhanden)',
-	'HIDEUSERS' 					=> 'Abschnitte für folgende Benutzer ausblenden:',
+	'HIDSECTIONTITLE' 				=> 'Welche Abschnitte mÃ¶chten Sie ausblenden?',
+	'HIDEPAGES' 					=> 'Abschnitt "<strong>Seiten</strong>" ausblenden?',
+	'HIDEFILES' 					=> 'Abschnitt "<strong>Dateien</strong>" ausblenden?',
+	'HIDETHEMES' 					=> 'Abschnitt "<strong>Themen</strong>" ausblenden?',
+	'HIDEBACKUP' 					=> 'Abschnitt "<strong>Backup</strong>" ausblenden?',
+	'HIDEPLUGIN' 					=> 'Abschnitt "<strong>Plugin</strong>" ausblenden?',
+	'HIDESUPPORT' 					=> 'Abschnitt "<strong>Support</strong>" ausblenden?',
+	'HIDESETTINGS' 					=> 'Abschnitt "<strong>MassiveAdmin-Einstellungen</strong>" ausblenden?',
+	'HIDEI18NGALLERY' 				=> 'Abschnitt "<strong>i18n-Galerie</strong>" ausblenden? (falls vorhanden)',
+	'HIDEUSERS' 					=> 'Abschnitte fÃ¼r folgende Benutzer ausblenden:',
 
 	//user manager
 	'USERMANAGER' 					=> 'Benutzer verwalten',
@@ -57,39 +57,39 @@ $i18n = [
 	'USERHELP' 						=> 'Benutzerhilfe',
 
 	//menu external
-	'MENUEXTERNAL' 					=> 'Benutzerdefinierter Menü-Link-Manager',
+	'MENUEXTERNAL' 					=> 'Benutzerdefinierter MenÃ¼-Link-Manager',
 	'LINKNAME' 						=> 'Linkname:',
 	'LINKURL' 						=> 'Link-URL:',
 	'LINKICON' 						=> 'Link-Symbol',
-	'NEWWINDOW' 					=> 'Link in neuem Fenster öffnen?',
+	'NEWWINDOW' 					=> 'Link in neuem Fenster Ã¶ffnen?',
 	'MOREICONS'  					=> '(Weitere Symbole finden Sie hier.):',
-	'ADDLINK' 						=> 'Neuen Link hinzufügen',
+	'ADDLINK' 						=> 'Neuen Link hinzufÃ¼gen',
 
 	//own footer option
 	'OWNFOOTERTITLE' 				=> 'White-Label-Optionen',
-	'OWNFOOTERNAME' 				=> 'Benutzerdefinierter Fußzeilenname:',
-	'OWNFOOTERICON' 				=> 'Benutzerdefiniertes Fußzeilensymbol (max. 256 Pixel Höhe | .jpg, .jpeg, .png, .gif)',
+	'OWNFOOTERNAME' 				=> 'Benutzerdefinierter FuÃŸzeilenname:',
+	'OWNFOOTERICON' 				=> 'Benutzerdefiniertes FuÃŸzeilensymbol (max. 256 Pixel HÃ¶he | .jpg, .jpeg, .png, .gif)',
 	'OWNLOGO' 						=> 'Benutzerdefiniertes Logo auf der Anmeldeseite?',
-	'OWNFOOTERLINK' 				=> 'Benutzerdefinierter Fußzeilen-Link:',
+	'OWNFOOTERLINK' 				=> 'Benutzerdefinierter FuÃŸzeilen-Link:',
 	'OWNFOOTERHEADER' 				=> 'Benutzerdefiniertes Header-CSS/Skripte:',
-	'OWNFOOTERFOOTER' 				=> 'Benutzerdefinierte Fußzeilenskripte:',
+	'OWNFOOTERFOOTER' 				=> 'Benutzerdefinierte FuÃŸzeilenskripte:',
 
 	//owncolor
-	'CHANGETITLECOLOR' 				=> 'CMS-Farben ändern',
+	'CHANGETITLECOLOR' 				=> 'CMS-Farben Ã¤ndern',
 	'MAINCOLOR' 					=> 'Hauptfarbe:',
 	'BGCOLOR' 						=> 'Hintergrundfarbe:',
-	'CHANGENAME' 					=> 'Ändern Sie den Spitznamen in einen anderen als den Administrator-Spitznamen',
+	'CHANGENAME' 					=> 'Ã„ndern Sie den Spitznamen in einen anderen als den Administrator-Spitznamen',
 
 	//snippet
 	'SNIPPET' 						=> 'Snippets',
-	'ADDSNIPPET' 					=> 'Snippet hinzufügen',
+	'ADDSNIPPET' 					=> 'Snippet hinzufÃ¼gen',
 	'EDITSNIPPET' 					=> 'Snippets bearbeiten',
 	'TITLESNIPPET' 					=> 'Titel (ohne Leerzeichen)',
 	'SUBMITSNIPPET' 				=> 'Snippets speichern',
 
 	//migrate
 	'MIGRATETITLE' 					=> 'Site-Migration & SSL',
-	'MIGRATEDOMAIN' 				=> 'Domänenmigration',
+	'MIGRATEDOMAIN' 				=> 'DomÃ¤nenmigration',
 	'OLDDOMAIN' 					=> 'Alte Website-Adresse',
 	'NEWDOMAIN' 					=> 'Neue Website-Adresse',
 	'REPLACEDOMAIN' 				=> 'URL ersetzen',
@@ -105,9 +105,9 @@ $i18n = [
 
 	//login options
 	'LOGINOPTIONS' 					=> 'Anmeldeoptionen',
-	'TURNONSHOWPASSWORDTITLE' 		=> 'Schaltfläche „Passwort anzeigen“',
-	'SHOWPASSWORDQUESTION' 			=> 'Schaltfläche „Passwort anzeigen“ beim Anmelden aktivieren?',
-	'REMOVEFORGETPASSWORDTITLE' 	=> '„Passwort vergessen?“ entfernen',
+	'TURNONSHOWPASSWORDTITLE' 		=> 'SchaltflÃ¤che "Passwort anzeigen"',
+	'SHOWPASSWORDQUESTION' 			=> 'SchaltflÃ¤che "Passwort anzeigen" beim Anmelden aktivieren?',
+	'REMOVEFORGETPASSWORDTITLE' 	=> '"Passwort vergessen?" entfernen',
 	'SAVESETTINGS' 					=> 'Einstellungen speichern',
 
 	//GSCONFIG
@@ -115,7 +115,7 @@ $i18n = [
 	'GSCONFIGSAVE' 					=> 'GSCONFIG-Einstellungen speichern',
 
 	'UNISTALLER' 					=> 'Plugins deinstallieren',
-	'UNISTALLQUESTION' 				=> 'Sie möchten deinstallieren',
+	'UNISTALLQUESTION' 				=> 'Sie mÃ¶chten deinstallieren',
 
 	//mToper
 	"TAB_PAGES" 					=> 'Seiten',
@@ -139,7 +139,7 @@ $i18n = [
 
 	'FRONTENDTITLE' 				=> 'Frontend-Einstellungen',
 	'TURNONMTOPER' 					=> 'Frontend-Leiste einschalten?',
-	'STYLEINFO' 					=> 'Stil für FrontEnd-Seitenleiste',
+	'STYLEINFO' 					=> 'Stil fÃ¼r FrontEnd-Seitenleiste',
 	'ADMINTHEMESELECTOR' 			=> 'Admin Theme Selector',
 
 	//manage users
@@ -147,14 +147,14 @@ $i18n = [
 	'EMAIL' 						=> 'e-mail:',
 	'PASSWORD' 						=> 'Passwort:',
 	'LANG' 							=> 'Sprache:',
-	'CHANGEPLACEHOLDER' 			=> 'nur ändern, wenn Sie ändern möchten',
+	'CHANGEPLACEHOLDER' 			=> 'nur Ã¤ndern, wenn Sie Ã¤ndern mÃ¶chten',
 
 
 	//new on 5.0
 
 	'FILECREATED' 					=> 'Datei erstellt!',
 	'WATCHEXAMPLE' 					=> 'Beispielstruktur anzeigen',
-	'HOWUSETHEMECONFIG' 			=> 'Wenn Sie Einstellungen für Ihre Vorlage verwenden möchten, erstellen Sie einfach <code style="color:blue;">settings.json</code> im Ordner der Vorlage, die Sie verwenden, und wenden Sie die entsprechende Struktur an wie im Beispiel. Wenden Sie dann <b style="color:green;">mats("fieldname")</b> oder <b style="color:green;">r_mats("fieldname")</b> für die Rückgabefunktion an die entsprechenden Felder.',
+	'HOWUSETHEMECONFIG' 			=> 'Wenn Sie Einstellungen fÃ¼r Ihre Vorlage verwenden mÃ¶chten, erstellen Sie einfach <code style="color:blue;">settings.json</code> im Ordner der Vorlage, die Sie verwenden, und wenden Sie die entsprechende Struktur an wie im Beispiel. Wenden Sie dann <b style="color:green;">mats("fieldname")</b> oder <b style="color:green;">r_mats("fieldname")</b> fÃ¼r die RÃ¼ckgabefunktion an die entsprechenden Felder.',
 	'HOWCREATETITLE' 				=> 'Wie erstelle ich meine eigenen Einstellungen?',
 	'TUTORIALHOWCREATESETTINGS' 	=> 'Erstellen Sie Ihre <code style="color:blue;">settings.json</code> im Stammverzeichnis Ihres Theme-Ordners, mit einer Struktur basierend auf diesem Beispiel mit verschiedenen Arten von Optionen',
 	'THEMECONFIGURATORNAME' 		=> 'Theme-Konfigurator',


### PR DESCRIPTION
Hi,
de_DE language file was using ISO 8859-15 encoding and causing issues with special characters, see screenshot below.
I converted the file to UTF-8 and all characters are shown correct now.

![grafik](https://github.com/multicolor-rgb/Massive-Admin-Theme/assets/26674558/3acb6ccb-4b4b-448e-9433-e9a04ce3614e)
